### PR TITLE
fix(lexicon-zod-schemas)

### DIFF
--- a/src/services/bsky-sdk/lexicon-zod-schemas.ts
+++ b/src/services/bsky-sdk/lexicon-zod-schemas.ts
@@ -170,7 +170,7 @@ const additionalZodSchemaMap = {
   bskyAppSetActiveProgressGuide: z.object({
     guide: z.string().optional(),
   }),
-  bskyAppUpsertNux: argsToArgSchema([NuxSchema]),
+  bskyAppUpsertNux: metaMixin(NuxSchema),
   bskyAppRemoveNuxs: metaMixin(z.array(metaMixin(z.string())), { label: 'ids' }),
 };
 


### PR DESCRIPTION
replace unnecessary usage of argsToARgSchema with existing object schema