### PR TITLE
feat/virtual-paths

### DIFF
--- a/src/components/ui/oauth-playground/sdk-form/array-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/array-form-field.tsx
@@ -14,11 +14,16 @@ function ArrayFormField({
   form,
   path,
   depth = 0,
+  options = {},
 }: {
   schema: { [key: string]: any };
   form: UseFormReturn;
   path: string;
   depth?: number;
+  options?: {
+    label?: string;
+    virtualPath?: string;
+  };
 }) {
   const [index, setIndex] = useState(-1);
 
@@ -28,11 +33,13 @@ function ArrayFormField({
     return schema;
   }
 
-  const itemSchema = schema._def?.innerType?._def.type || schema._def?.type || schema.type;
-  const nestedSchema = deeper(itemSchema);
+  const nestedSchema = deeper(
+    schema._def?.innerType?._def.type || schema._def?.type || schema.type
+  );
   const nestedType = nestedSchema._def.typeName;
-  const nestedSchemaMeta = schema.meta ? schema.meta() : {}
-  const nestedLabel = nestedSchemaMeta.label || path;
+  const arrayMetadata = schema.meta ? schema.meta() : {};
+  const virtualPath = arrayMetadata.virtualPath || options.virtualPath
+  const arrayLabel = arrayMetadata.label || options.label || virtualPath || path;
 
   let isOptional = schema.isOptional;
 
@@ -41,7 +48,7 @@ function ArrayFormField({
   return (
     <FormItem>
       <FormLabel>
-        {nestedLabel}
+        {arrayLabel}
         {isOptional && (
           <>
             &nbsp;&nbsp;
@@ -53,7 +60,7 @@ function ArrayFormField({
       </FormLabel>
       <FormDescription>{schema.description}</FormDescription>
       <div className={`p-${2 * depth} ${depth % 2 ? 'bg-slate-50' : 'bg-white'}`}>
-        {index === -1 ? <p className="font-mono">No {nestedLabel} provided</p> : <></>}
+        {index === -1 ? <p className="font-mono">No {arrayLabel} provided</p> : <></>}
         {(() => {
           const items = [];
 
@@ -101,7 +108,7 @@ function ArrayFormField({
                     form={form}
                     path={nestedPath}
                     options={{
-                      label: `${nestedLabel}.${i}`,
+                      label: `${arrayLabel}.${i}`,
                     }}
                   />
                 );
@@ -126,7 +133,7 @@ function ArrayFormField({
         }}
       >
         <Plus />
-        Add more `{nestedLabel}`
+        Add more `{arrayLabel}`
       </Button>
     </FormItem>
   );

--- a/src/components/ui/oauth-playground/sdk-form/array-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/array-form-field.tsx
@@ -38,7 +38,7 @@ function ArrayFormField({
   );
   const nestedType = nestedSchema._def.typeName;
   const arrayMetadata = schema.meta ? schema.meta() : {};
-  const virtualPath = arrayMetadata.virtualPath || options.virtualPath
+  const virtualPath = arrayMetadata.virtualPath || options.virtualPath;
   const arrayLabel = arrayMetadata.label || options.label || virtualPath || path;
 
   let isOptional = schema.isOptional;
@@ -77,6 +77,7 @@ function ArrayFormField({
                     schema={nestedSchema}
                     form={form}
                     path={nestedPath}
+                    options={virtualPath ? { virtualPath: `${virtualPath}.${i}` } : {}}
                   />
                 );
                 break;
@@ -87,6 +88,7 @@ function ArrayFormField({
                     schema={nestedSchema}
                     form={form}
                     path={nestedPath}
+                    options={virtualPath ? { virtualPath: `${virtualPath}.${i}` } : {}}
                   />
                 );
                 break;
@@ -97,6 +99,7 @@ function ArrayFormField({
                     form={form}
                     path={nestedPath}
                     depth={depth + 1}
+                    options={virtualPath ? { virtualPath: `${virtualPath}.${i}` } : {}}
                   />
                 );
               case 'ZodOptional':
@@ -107,9 +110,7 @@ function ArrayFormField({
                     schema={nestedSchema}
                     form={form}
                     path={nestedPath}
-                    options={{
-                      label: `${arrayLabel}.${i}`,
-                    }}
+                    options={virtualPath ? { virtualPath: `${virtualPath}.${i}` } : {}}
                   />
                 );
             }

--- a/src/components/ui/oauth-playground/sdk-form/boolean-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/boolean-form-field.tsx
@@ -16,16 +16,23 @@ function BooleanFormField({
   schema,
   form,
   path,
+  options = {},
 }: {
   schema: { [key: string]: any };
   form: UseFormReturn;
   path: string;
+  options?: {
+    label?: string;
+    virtualPath?: string;
+  };
 }) {
   let isOptional = schema.isOptional;
 
   if (typeof isOptional === 'function') isOptional = isOptional();
 
   const schemaMetadata = schema.meta ? schema.meta() : {};
+  const virtualPath = schemaMetadata.virtualPath || options.virtualPath;
+  const label = schemaMetadata.label || options.label || virtualPath || path;
 
   return (
     <FormField
@@ -36,7 +43,7 @@ function BooleanFormField({
         return (
           <FormItem>
             <FormLabel>
-              {schemaMetadata.label || path}
+              {label}
               {isOptional && (
                 <>
                   &nbsp;&nbsp;
@@ -48,9 +55,11 @@ function BooleanFormField({
             </FormLabel>
             <FormDescription>{schema.description}</FormDescription>
             <FormControl>
-              <RadioGroup onValueChange={(val: string) => {
-                form.setValue(field.name, Boolean(val))
-              }}>
+              <RadioGroup
+                onValueChange={(val: string) => {
+                  form.setValue(field.name, Boolean(val));
+                }}
+              >
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="true" id="r2" />
                   <Label htmlFor="r2">true</Label>

--- a/src/components/ui/oauth-playground/sdk-form/date-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/date-form-field.tsx
@@ -1,75 +1,74 @@
 import {
-    FormControl,
-    FormDescription,
-    FormField,
-    FormItem,
-    FormLabel,
-    FormMessage,
-  } from '../../shadcn/form';
-  
-  import { Input } from '../../shadcn/input';
-  import { UseFormReturn } from 'react-hook-form';
-  import { Badge } from '../../shadcn/badge';
-  
-  function DateFormField({
-    schema,
-    form,
-    path,
-  }: {
-    schema: { [key: string]: any };
-    form: UseFormReturn;
-    path: string;
-  }) {
-    let defaultValue =
-      schema._def?.defaultValue || schema._def?.innerType?._def?.defaultValue || schema.defaultValue;
-  
-    let isOptional = schema.isOptional;
-  
-    if (typeof isOptional === 'function') isOptional = isOptional();
-  
-    const schemaMetadata = schema.meta ? schema.meta() : {};
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '../../shadcn/form';
 
-    return (
-      <FormField
-        control={form.control}
-        key={path}
-        name={path}
-        render={({ field }) => {
-          return (
-            <FormItem>
-              <FormLabel>
-                {schemaMetadata.label || path}
-                {isOptional && (
-                  <>
-                    &nbsp;&nbsp;
-                    <Badge className="opacity-80" variant="secondary">
-                      Optional
-                    </Badge>
-                  </>
-                )}
-              </FormLabel>
-              <FormDescription>{schema.description}</FormDescription>
-              <FormControl>
-                <Input
-                  id="kitty"
-                  type="datetime-local"
-                  defaultValue={defaultValue ? defaultValue() : undefined}
-                  className="bg-white"
-                  key={field.name}
-                  placeholder=""
-                  onChange={(e) => {
-                    const date = new Date(e.target.value);
-                    form.setValue(field.name, date.toISOString());
-                  }}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          );
-        }}
-      />
-    );
-  }
-  
-  export default DateFormField;
-  
+import { Input } from '../../shadcn/input';
+import { UseFormReturn } from 'react-hook-form';
+import { Badge } from '../../shadcn/badge';
+
+function DateFormField({
+  schema,
+  form,
+  path,
+}: {
+  schema: { [key: string]: any };
+  form: UseFormReturn;
+  path: string;
+}) {
+  let defaultValue =
+    schema._def?.defaultValue || schema._def?.innerType?._def?.defaultValue || schema.defaultValue;
+
+  let isOptional = schema.isOptional;
+
+  if (typeof isOptional === 'function') isOptional = isOptional();
+
+  const schemaMetadata = schema.meta ? schema.meta() : {};
+
+  return (
+    <FormField
+      control={form.control}
+      key={path}
+      name={path}
+      render={({ field }) => {
+        return (
+          <FormItem>
+            <FormLabel>
+              {schemaMetadata.label || path}
+              {isOptional && (
+                <>
+                  &nbsp;&nbsp;
+                  <Badge className="opacity-80" variant="secondary">
+                    Optional
+                  </Badge>
+                </>
+              )}
+            </FormLabel>
+            <FormDescription>{schema.description}</FormDescription>
+            <FormControl>
+              <Input
+                id="kitty"
+                type="datetime-local"
+                defaultValue={defaultValue ? defaultValue() : undefined}
+                className="bg-white"
+                key={field.name}
+                placeholder=""
+                onChange={(e) => {
+                  const date = new Date(e.target.value);
+                  form.setValue(field.name, date.toISOString());
+                }}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        );
+      }}
+    />
+  );
+}
+
+export default DateFormField;

--- a/src/components/ui/oauth-playground/sdk-form/date-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/date-form-field.tsx
@@ -15,10 +15,15 @@ function DateFormField({
   schema,
   form,
   path,
+  options = {},
 }: {
   schema: { [key: string]: any };
   form: UseFormReturn;
   path: string;
+  options?: {
+    label?: string;
+    virtualPath?: string;
+  };
 }) {
   let defaultValue =
     schema._def?.defaultValue || schema._def?.innerType?._def?.defaultValue || schema.defaultValue;
@@ -28,6 +33,8 @@ function DateFormField({
   if (typeof isOptional === 'function') isOptional = isOptional();
 
   const schemaMetadata = schema.meta ? schema.meta() : {};
+  const virtualPath = schemaMetadata.virtualPath || options.virtualPath;
+  const label = schemaMetadata.label || options.label || virtualPath || path;
 
   return (
     <FormField
@@ -38,7 +45,7 @@ function DateFormField({
         return (
           <FormItem>
             <FormLabel>
-              {schemaMetadata.label || path}
+              {label}
               {isOptional && (
                 <>
                   &nbsp;&nbsp;

--- a/src/components/ui/oauth-playground/sdk-form/file-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/file-form-field.tsx
@@ -21,6 +21,7 @@ function FileFormField({
   form: UseFormReturn;
   path: string;
   options?: {
+    label?: string;
     virtualPath?: string;
   };
 }) {
@@ -33,7 +34,7 @@ function FileFormField({
 
   const schemaMetadata = schema.meta ? schema.meta() : {};
   const virtualPath = schemaMetadata.virtualPath || options.virtualPath;
-  const label = schemaMetadata.label || virtualPath || path;
+  const label = schemaMetadata.label || options.label || virtualPath || path;
 
   return (
     <FormField

--- a/src/components/ui/oauth-playground/sdk-form/file-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/file-form-field.tsx
@@ -15,10 +15,14 @@ function FileFormField({
   schema,
   form,
   path,
+  options = {},
 }: {
   schema: { [key: string]: any };
   form: UseFormReturn;
   path: string;
+  options?: {
+    virtualPath?: string;
+  };
 }) {
   let defaultValue =
     schema._def?.defaultValue || schema._def?.innerType?._def?.defaultValue || schema.defaultValue;
@@ -28,6 +32,8 @@ function FileFormField({
   if (typeof isOptional === 'function') isOptional = isOptional();
 
   const schemaMetadata = schema.meta ? schema.meta() : {};
+  const virtualPath = schemaMetadata.virtualPath || options.virtualPath;
+  const label = schemaMetadata.label || virtualPath || path;
 
   return (
     <FormField
@@ -38,7 +44,7 @@ function FileFormField({
         return (
           <FormItem>
             <FormLabel>
-              {schemaMetadata.label || path}
+              {label}
               {isOptional && (
                 <>
                   &nbsp;&nbsp;

--- a/src/components/ui/oauth-playground/sdk-form/input-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/input-form-field.tsx
@@ -31,6 +31,7 @@ function InputFormField({
   path: string;
   options?: {
     label?: string;
+    virtualPath?: string;
   };
 }) {
   let defaultValue =
@@ -46,11 +47,8 @@ function InputFormField({
     ? (schema as { [key: string]: any }).meta()
     : {};
 
-  let label = path;
-
-  if (schemaMetadata.label || options.label) {
-    label = schemaMetadata.label || options.label;
-  }
+  const virtualPath = schemaMetadata.virtualPath || options.virtualPath;
+  const label = schemaMetadata.label || options.label || virtualPath || path;
 
   return (
     <FormField

--- a/src/components/ui/oauth-playground/sdk-form/object-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/object-form-field.tsx
@@ -44,11 +44,16 @@ function ObjectFormField({
   schema: rawSchema,
   path,
   depth = 0,
+  options = {},
 }: {
   form: UseFormReturn;
   schema: WrappedZodObject | WrappedZodOptional<WrappedZodObject>;
   path: string;
   depth?: number;
+  options?: {
+    label?: string;
+    virtualPath?: string;
+  };
 }) {
   const [isEnabled, setIsEnabled] = useState<boolean>(false);
   const schema =
@@ -65,12 +70,8 @@ function ObjectFormField({
   const isFieldEnabled = isEnabled || !!!depth;
   const isFieldOptional = isOptional && !!depth;
   const uiDepth = schemaMetadata.noDepth === true ? 0 : depth;
-
-  let label = path;
-
-  if (schemaMetadata.label) {
-    label = schemaMetadata.label;
-  }
+  const virtualPath = schemaMetadata.virtualPath || options.virtualPath;
+  const label = schemaMetadata.label || options.label || virtualPath || path;
 
   return (
     <FormItem>
@@ -152,13 +153,7 @@ function ObjectFormField({
                     case 'date':
                       return <DateFormField schema={fieldSchema} form={form} path={fieldPath} />;
                     default:
-                      return (
-                        <InputFormField
-                          form={form}
-                          schema={fieldSchema}
-                          path={fieldPath}
-                        />
-                      );
+                      return <InputFormField form={form} schema={fieldSchema} path={fieldPath} />;
                   }
                 })()}
               </>

--- a/src/components/ui/oauth-playground/sdk-form/object-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/object-form-field.tsx
@@ -126,6 +126,7 @@ function ObjectFormField({
                           form={form}
                           path={fieldPath}
                           depth={childDepth}
+                          options={virtualPath ? { virtualPath: `${virtualPath}.${fieldName}` } : {}}
                         />
                       );
                     case 'ZodArray':
@@ -135,6 +136,7 @@ function ObjectFormField({
                           form={form}
                           path={fieldPath}
                           depth={childDepth}
+                          options={virtualPath ? { virtualPath: `${virtualPath}.${fieldName}` } : {}}
                         />
                       );
                     case 'ZodUnion':
@@ -144,16 +146,45 @@ function ObjectFormField({
                           form={form}
                           path={fieldPath}
                           depth={childDepth}
+                          options={virtualPath ? { virtualPath: `${virtualPath}.${fieldName}` } : {}}
                         />
                       );
                     case 'ZodBoolean':
-                      return <BooleanFormField schema={fieldSchema} form={form} path={fieldPath} />;
+                      return (
+                        <BooleanFormField
+                          schema={fieldSchema}
+                          form={form}
+                          path={fieldPath}
+                          options={virtualPath ? { virtualPath: `${virtualPath}.${fieldName}` } : {}}
+                        />
+                      );
                     case 'file':
-                      return <FileFormField schema={fieldSchema} form={form} path={fieldPath} />;
+                      return (
+                        <FileFormField
+                          schema={fieldSchema}
+                          form={form}
+                          path={fieldPath}
+                          options={virtualPath ? { virtualPath: `${virtualPath}.${fieldName}` } : {}}
+                        />
+                      );
                     case 'date':
-                      return <DateFormField schema={fieldSchema} form={form} path={fieldPath} />;
+                      return (
+                        <DateFormField
+                          schema={fieldSchema}
+                          form={form}
+                          path={fieldPath}
+                          options={virtualPath ? { virtualPath: `${virtualPath}.${fieldName}` } : {}}
+                        />
+                      );
                     default:
-                      return <InputFormField form={form} schema={fieldSchema} path={fieldPath} />;
+                      return (
+                        <InputFormField
+                          form={form}
+                          schema={fieldSchema}
+                          path={fieldPath}
+                          options={virtualPath ? { virtualPath: `${virtualPath}.${fieldName}` } : {}}
+                        />
+                      );
                   }
                 })()}
               </>

--- a/src/components/ui/oauth-playground/sdk-form/union-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/union-form-field.tsx
@@ -92,6 +92,7 @@ function UnionFormField({
                         form={form}
                         path={path}
                         depth={depth}
+                        options={virtualPath ? { virtualPath: `${virtualPath}` } : {}}
                       />
                     );
                   case 'ZodArray':
@@ -101,6 +102,7 @@ function UnionFormField({
                         form={form}
                         path={path}
                         depth={depth}
+                        options={virtualPath ? { virtualPath: `${virtualPath}` } : {}}
                       />
                     );
                   case 'ZodUnion':
@@ -110,10 +112,18 @@ function UnionFormField({
                         form={form}
                         path={path}
                         depth={depth}
+                        options={virtualPath ? { virtualPath: `${virtualPath}` } : {}}
                       />
                     );
                   default:
-                    return <InputFormField form={form} schema={optionSchema} path={path} />;
+                    return (
+                      <InputFormField
+                        form={form}
+                        schema={optionSchema}
+                        path={path}
+                        options={virtualPath ? { virtualPath: `${virtualPath}` } : {}}
+                      />
+                    );
                 }
               })()}
             </TabsContent>

--- a/src/components/ui/oauth-playground/sdk-form/union-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/union-form-field.tsx
@@ -12,11 +12,16 @@ function UnionFormField({
   schema,
   path,
   depth = 0,
+  options = {},
 }: {
   form: UseFormReturn;
   schema: ZodUnion<any> | ZodOptional<ZodUnion<any>>;
   path: string;
   depth?: number;
+  options?: {
+    label?: string;
+    virtualPath?: string;
+  };
 }) {
   const unionOptions: Array<{ [key: string]: any }> =
     (schema as any).options ||
@@ -30,11 +35,13 @@ function UnionFormField({
   const schemaMetadata = (schema as { [key: string]: any }).meta
     ? (schema as { [key: string]: any }).meta()
     : {};
+  const virtualPath = schemaMetadata.virtualPath || options.virtualPath;
+  const label = schemaMetadata.label || options.label || virtualPath || path;
 
   return (
     <FormItem className="">
       <FormLabel>
-        {schemaMetadata.label || path}
+        {label}
         {isOptional && (
           <>
             &nbsp;&nbsp;
@@ -47,10 +54,10 @@ function UnionFormField({
       <FormDescription>{schema.description}</FormDescription>
       <Tabs
         // onValueChange={(value) => {
-          // console.log(form.getValues().embed)
-          // form.getValues()?.embed && Object.keys(form.getValues().embed).forEach((key) => {
-          //   form.setValue(`${path}.${key}`, undefined)
-          // })
+        // console.log(form.getValues().embed)
+        // form.getValues()?.embed && Object.keys(form.getValues().embed).forEach((key) => {
+        //   form.setValue(`${path}.${key}`, undefined)
+        // })
         // }}
         className={``}
       >
@@ -60,7 +67,7 @@ function UnionFormField({
 
             return (
               <TabsTrigger onClick={() => {}} value={`${i}`}>
-                {optionsSchema.meta && optionsSchema.meta().key || `Variant ${i + 1}`}
+                {(optionsSchema.meta && optionsSchema.meta().key) || `Variant ${i + 1}`}
               </TabsTrigger>
             );
           })}

--- a/src/components/ui/oauth-playground/sdk-form/union-form-field.tsx
+++ b/src/components/ui/oauth-playground/sdk-form/union-form-field.tsx
@@ -52,15 +52,7 @@ function UnionFormField({
         )}
       </FormLabel>
       <FormDescription>{schema.description}</FormDescription>
-      <Tabs
-        // onValueChange={(value) => {
-        // console.log(form.getValues().embed)
-        // form.getValues()?.embed && Object.keys(form.getValues().embed).forEach((key) => {
-        //   form.setValue(`${path}.${key}`, undefined)
-        // })
-        // }}
-        className={``}
-      >
+      <Tabs>
         <TabsList className={``}>
           {unionOptions.map((o, i) => {
             const optionsSchema = o._def?.innerType || o;
@@ -130,51 +122,6 @@ function UnionFormField({
           );
         })}
       </Tabs>
-      {/* {Object.keys(schemaShape).map((fieldName, fieldIdx) => {
-          const fieldSchema = schemaShape[fieldName];
-          const fieldType =
-            fieldSchema._def?.innerType?._def?.typeName || fieldSchema._def?.typeName;
-          const fieldPath = `${path ? `${path}.` : ''}${fieldName}` as string;
-
-          return (
-            <>
-              {fieldIdx ? <br /> : <></>}
-              {(() => {
-                switch (fieldType) {
-                  case 'ZodObject':
-                    return (
-                      <ObjectFormField
-                        schema={schemaShape[fieldName]}
-                        form={form}
-                        path={fieldPath}
-                        depth={depth + 1}
-                      />
-                    );
-                  case 'ZodArray':
-                    return (
-                      <ArrayFormField
-                        schema={schemaShape[fieldName]}
-                        form={form}
-                        path={fieldPath}
-                        depth={depth + 1}
-                      />
-                    );
-                  // case 'ZodUnion':
-                  //   input = (
-                  //     <UnionFormField
-                  //       schema={schemaShape[fieldName]}
-                  //       form={form}
-                  //       path={fieldPath}
-                  //       depth={depth + 1}
-                  //     />
-                  //   );
-                  default:
-                    return <InputFormField form={form} schema={fieldSchema} path={fieldPath} />;
-                }
-              })()}
-            </>
-          );
-        })} */}
     </FormItem>
   );
 }

--- a/src/services/bsky-sdk/lexicon-zod-schemas.ts
+++ b/src/services/bsky-sdk/lexicon-zod-schemas.ts
@@ -81,9 +81,9 @@ function argsToArgSchema(
 
   return metaMixin(
     z.object({
-      __args__: metaMixin(z.object(argMap), { noLabel: true, noDepth: true }),
+      __args__: metaMixin(z.object(argMap), { noLabel: true }),
     }),
-    objMeta
+    {noDepth: true, ...objMeta}
   );
 }
 
@@ -117,12 +117,12 @@ const additionalZodSchemaMap = {
     metaMixin(z.string().optional(), { hidden: true, noDescription: true, noLabel: true }),
   ]),
   overwriteSavedFeeds: argsToArgSchema([
-    metaMixin(z.array(SavedFeedSchema), { label: 'savedFeeds' }),
+    metaMixin(z.array(SavedFeedSchema), { virtualPath: 'savedFeeds' }),
   ]),
-  updateSavedFeeds: argsToArgSchema([metaMixin(z.array(SavedFeedSchema), { label: 'savedFeeds' })]),
+  updateSavedFeeds: argsToArgSchema([metaMixin(z.array(SavedFeedSchema), { virtualPath: 'savedFeeds' })]),
   addSavedFeed: metaMixin(UnwrappedSavedFeedSchema, { noLabel: true }),
   removeSavedFeeds: argsToArgSchema([
-    metaMixin(z.array(metaMixin(z.string())), { label: 'savedFeeds' }),
+    metaMixin(z.array(metaMixin(z.string())), { virtualPath: 'savedFeeds' }),
   ]),
   setAdultContentEnabled: argsToArgSchema([
     metaMixin(z.coerce.boolean(), { label: 'adult content enabled' }),
@@ -141,12 +141,14 @@ const additionalZodSchemaMap = {
     metaMixin(z.string(), { label: 'feed' }),
     metaMixin(
       z.object({
-        hideReplies: metaMixin(z.boolean(), { label: 'hideReplies' }),
-        hideRepliesByUnfollowed: metaMixin(z.boolean(), { label: 'hideRepliesByUnfollowed' }),
-        hideRepliesByLikeCount: metaMixin(z.coerce.number(), { label: 'hideRepliesByLikeCount' }),
-        hideReposts: metaMixin(z.boolean(), { label: 'hideReposts' }),
-        hideQuotePosts: metaMixin(z.boolean(), { label: 'hideQuotePosts' }),
-      })
+        hideReplies: metaMixin(z.boolean(), { label: '' }),
+        hideRepliesByUnfollowed: metaMixin(z.boolean(), { label: '' }),
+        hideRepliesByLikeCount: metaMixin(z.coerce.number(), { label: '' }),
+        hideReposts: metaMixin(z.boolean(), { label: '' }),
+        hideQuotePosts: metaMixin(z.boolean(), { label: '' }),
+      }), {
+        virtualPath: 'preferences'
+      }
     ),
   ]),
   setThreadViewPrefs: metaMixin(
@@ -161,17 +163,17 @@ const additionalZodSchemaMap = {
     })
   ),
   addMutedWord: metaMixin(MutedWordSchema, { noLabel: true, noDepth: true }),
-  addMutedWords: argsToArgSchema([z.array(MutedWordSchema)]),
-  updateMutedWord: metaMixin(MutedWordSchema, { noLabel: true, noDepth: true }),
-  removeMutedWord: metaMixin(MutedWordSchema, { noLabel: true, noDepth: true }),
-  removeMutedWords: argsToArgSchema([z.array(MutedWordSchema)]),
-  bskyAppQueueNudges: argsToArgSchema([metaMixin(z.array(metaMixin(z.string())), { label: 'nudges' })]),
-  bskyAppDismissNudges: argsToArgSchema([metaMixin(z.array(metaMixin(z.string())), { label: 'nudges' })]),
+  addMutedWords: argsToArgSchema([metaMixin(z.array(MutedWordSchema), {virtualPath: 'mutedWords'})]),
+  updateMutedWord: metaMixin(MutedWordSchema),
+  removeMutedWord: metaMixin(MutedWordSchema),
+  removeMutedWords: argsToArgSchema([metaMixin(z.array(MutedWordSchema), {virtualPath: 'mutedWords'})]),
+  bskyAppQueueNudges: argsToArgSchema([metaMixin(z.array(metaMixin(z.string())), { virtualPath: 'nudges' })]),
+  bskyAppDismissNudges: argsToArgSchema([metaMixin(z.array(metaMixin(z.string())), { virtualPath: 'nudges' })]),
   bskyAppSetActiveProgressGuide: z.object({
     guide: z.string().optional(),
   }),
   bskyAppUpsertNux: metaMixin(NuxSchema),
-  bskyAppRemoveNuxs:argsToArgSchema([metaMixin(z.array(metaMixin(z.string())), { label: 'ids' })]),
+  bskyAppRemoveNuxs:argsToArgSchema([metaMixin(z.array(metaMixin(z.string())), { virtualPath: 'ids' })]),
 };
 
 /**


### PR DESCRIPTION
Add support for `virtualPath` which allows for overriding the display name of an input field at the path level (array element, object property, union subtype).

Unlike the `label` option, `virtualPath` is inherited and utilized by nested paths (nested objects, arrays of objects, etc)